### PR TITLE
Fix broken link to 'Guide'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -248,7 +248,7 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="guide.html">here</a>.
+        <a href="/guide.html">here</a>.
       </p>
 
       <!-- JSON Server -->

--- a/public/index.html
+++ b/public/index.html
@@ -248,7 +248,7 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="/guide.html">here</a>.
+        <a href="/guide/">here</a>.
       </p>
 
       <!-- JSON Server -->


### PR DESCRIPTION
The reference to guide.html was leading to a blank page. Added "/" to fix the issue.