### PR TITLE
Add delay to query parameters

### DIFF
--- a/public/guide.html
+++ b/public/guide.html
@@ -181,6 +181,12 @@ fetch('https://jsonplaceholder.typicode.com/posts/1/comments')
 <li><a href="https://jsonplaceholder.typicode.com/users/1/todos">https://jsonplaceholder.typicode.com/users/1/todos</a></li>
 <li><a href="https://jsonplaceholder.typicode.com/users/1/posts">https://jsonplaceholder.typicode.com/users/1/posts</a></li>
 </ul>
+<h3 id="delay">Delay</h3>
+<p>With any request, add a <code style="padding: 0 !important;">delay=N</code> query string parameter to simulate a slow-running API response.</p>
+<ul>
+<li><a href="https://jsonplaceholder.typicode.com/posts/1/comments?delay=500">https://jsonplaceholder.typicode.com/posts/1/comments?delay=500</a></li>
+<li><a href="https://jsonplaceholder.typicode.com/posts?userId=1&delay=1000">https://jsonplaceholder.typicode.com/posts?userId=1&delay=1000</a></li>
+</ul>
 <p></main></p>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -248,7 +248,7 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="/guide">here</a>.
+        <a href="/guide/">here</a>.
       </p>
 
       <!-- Delay -->

--- a/public/index.html
+++ b/public/index.html
@@ -248,7 +248,15 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="/guide/">here</a>.
+        <a href="guide.html">here</a>.
+      </p>
+
+      <!-- Delay -->
+      <h2>Simulate a delay</h2>
+
+      <p>
+        You can simulate a delay by adding a
+        <strong>delay</strong> query parameter (measured in milliseconds) to any route.
       </p>
 
       <!-- JSON Server -->

--- a/public/index.html
+++ b/public/index.html
@@ -248,7 +248,7 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="guide.html">here</a>.
+        <a href="/guide">here</a>.
       </p>
 
       <!-- Delay -->

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,17 @@ const app = jsonServer.create()
 const router = jsonServer.router(clone(data), { _isFake: true })
 
 app.use((req, res, next) => {
+  if (req.query.delay) {
+    const delay = parseInt(req.query.delay, 10)
+    if (delay > 0) {
+      setTimeout(next, delay)
+      return
+    }
+  }
+  next()
+})
+
+app.use((req, res, next) => {
   if (req.path === '/') return next()
   router.db.setState(clone(data))
   next()

--- a/templates/GUIDE.md
+++ b/templates/GUIDE.md
@@ -163,4 +163,11 @@ Available nested routes:
 * https://jsonplaceholder.typicode.com/users/1/todos
 * https://jsonplaceholder.typicode.com/users/1/posts
 
+### Delay
+
+With any request, add a <code style="padding: 0 !important;">delay=N</code> query string parameter to simulate a slow-running API response.
+
+* https://jsonplaceholder.typicode.com/posts/1/comments?delay=500
+* https://jsonplaceholder.typicode.com/posts?userId=1&delay=1000
+
 </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -195,7 +195,7 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="/guide">here</a>.
+        <a href="/guide/">here</a>.
       </p>
 
       <!-- Delay -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -195,7 +195,7 @@
 
       <p>
         <strong>Note</strong>: you can view detailed examples
-        <a href="guide.html">here</a>.
+        <a href="/guide">here</a>.
       </p>
 
       <!-- Delay -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -198,6 +198,14 @@
         <a href="guide.html">here</a>.
       </p>
 
+      <!-- Delay -->
+      <h2>Simulate a delay</h2>
+
+      <p>
+        You can simulate a delay by adding a
+        <strong>delay</strong> query parameter (measured in milliseconds) to any route.
+      </p>
+
       <!-- JSON Server -->
       <h2>Use your own data</h2>
       <!-- <p>

--- a/test/app.js
+++ b/test/app.js
@@ -8,6 +8,18 @@ test('GET /', (t) => {
     .expect(200, (err) => t.end(err))
 })
 
+test('GET /?delay=100', (t) => {
+  const start = Date.now()
+  request(app)
+    .get('/?delay=100')
+    .expect(200, (err) => {
+      const end = Date.now()
+      t.assert(end - start >= 100, `actual response time ${end - start}`)
+      t.assert(end - start < 200, `actual response time ${end - start}`)
+      t.end(err)
+    })
+})
+
 test('POST /', (t) => {
   const max = 10
   t.plan(max * 3)
@@ -33,4 +45,17 @@ test('POST /', (t) => {
           })
       })
   }
+})
+
+test('POST /posts?delay=100', (t) => {
+  const start = Date.now()
+  request(app)
+    .post('/posts?delay=100')
+    .send({ body: 'foo' })
+    .expect(201, (err) => {
+      const end = Date.now()
+      t.assert(end - start >= 100, `actual response time ${end - start}`)
+      t.assert(end - start < 200, `actual response time ${end - start}`)
+      t.end(err)
+    })
 })


### PR DESCRIPTION
Adding the ability to simulate a delay by adding a `?delay=N` query string parameter. This is for Issue #112

Also adding the fix for `/guide/` to the template since the previous fix only updated the HTML file itself, and was overwritten when the pages were rebuilt.